### PR TITLE
Fix iOS plugin for GoogleSignIn 9 API changes

### DIFF
--- a/src/ios/GooglePlus.h
+++ b/src/ios/GooglePlus.h
@@ -1,5 +1,6 @@
 #import <Cordova/CDVPlugin.h>
 #import <GoogleSignIn/GoogleSignIn.h>
+#import <GoogleSignIn/GIDAuthentication.h>
 
 @interface GooglePlus : CDVPlugin
 

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -57,7 +57,7 @@
 
     GIDSignIn *signIn = GIDSignIn.sharedInstance;
 
-    [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+    [signIn signInWithConfiguration:config presentingViewController:self.viewController completion:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
         if (error) {
             CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
@@ -113,7 +113,7 @@
 }
 
 - (void) disconnect:(CDVInvokedUrlCommand*)command {
-    [GIDSignIn.sharedInstance disconnectWithCallback:^(NSError * _Nullable error) {
+    [GIDSignIn.sharedInstance disconnectWithCompletion:^(NSError * _Nullable error) {
         if(error == nil) {
             CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"disconnected"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];


### PR DESCRIPTION
## Summary
- import the new GIDAuthentication header so the authentication property is visible
- switch to the completion-based sign-in and disconnect APIs required by GoogleSignIn 9

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e65c3a80832dbda54867677263d0