### PR TITLE
fix(ios): support newer GoogleSignIn sign-in result API

### DIFF
--- a/src/ios/GooglePlus.h
+++ b/src/ios/GooglePlus.h
@@ -1,4 +1,5 @@
 #import <Cordova/CDVPlugin.h>
+// Rely on the umbrella GoogleSignIn header instead of importing GIDAuthentication directly.
 #import <GoogleSignIn/GoogleSignIn.h>
 
 @interface GooglePlus : CDVPlugin

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -162,9 +162,17 @@
         SignInWithCompletionType implementation = (SignInWithCompletionType)[signIn methodForSelector:modernSignInSelector];
         implementation(signIn, modernSignInSelector, config, self.viewController, completion);
     } else {
-        [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-            [self sendPluginResultWithUser:user error:error];
-        }];
+        SEL legacySignInSelector = NSSelectorFromString(@"signInWithConfiguration:presentingViewController:callback:");
+        if ([signIn respondsToSelector:legacySignInSelector]) {
+            typedef void (*SignInWithCallbackType)(id, SEL, GIDConfiguration *, UIViewController *, void (^)(GIDGoogleUser * _Nullable, NSError * _Nullable));
+            SignInWithCallbackType implementation = (SignInWithCallbackType)[signIn methodForSelector:legacySignInSelector];
+            implementation(signIn, legacySignInSelector, config, self.viewController, ^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+                [self sendPluginResultWithUser:user error:error];
+            });
+        } else {
+            NSError *unsupportedError = [NSError errorWithDomain:@"GooglePlus" code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Google Sign-In API unsupported on this version."}];
+            [self sendPluginResultWithUser:nil error:unsupportedError];
+        }
     }
 }
 
@@ -220,9 +228,22 @@
             handleResult(error);
         });
     } else {
-        [signIn disconnectWithCallback:^(NSError * _Nullable error) {
-            handleResult(error);
-        }];
+        SEL legacyDisconnectSelector = NSSelectorFromString(@"disconnectWithCallback:");
+        if ([signIn respondsToSelector:legacyDisconnectSelector]) {
+            typedef void (*DisconnectWithCallbackType)(id, SEL, void (^ _Nullable)(NSError * _Nullable));
+            DisconnectWithCallbackType implementation = (DisconnectWithCallbackType)[signIn methodForSelector:legacyDisconnectSelector];
+            implementation(signIn, legacyDisconnectSelector, ^(NSError * _Nullable error) {
+                handleResult(error);
+            });
+        } else if ([signIn respondsToSelector:@selector(disconnect)]) {
+            typedef void (*DisconnectVoidType)(id, SEL);
+            DisconnectVoidType implementation = (DisconnectVoidType)[signIn methodForSelector:@selector(disconnect)];
+            implementation(signIn, @selector(disconnect));
+            handleResult(nil);
+        } else {
+            NSError *unsupportedError = [NSError errorWithDomain:@"GooglePlus" code:-1 userInfo:@{NSLocalizedDescriptionKey: @"Disconnect API unsupported on this version."}];
+            handleResult(unsupportedError);
+        }
     }
 }
 

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -2,10 +2,6 @@
 #import "objc/runtime.h"
 #import "GooglePlus.h"
 
-#if __has_include(<GoogleSignIn/GIDSignInResult.h>)
-#import <GoogleSignIn/GIDSignInResult.h>
-#endif
-
 @implementation GooglePlus
 
 - (void)pluginInitialize
@@ -69,14 +65,46 @@
 
     NSString *idToken = nil;
 
-#if __has_include(<GoogleSignIn/GIDSignInResult.h>)
-    if ([user respondsToSelector:@selector(idToken)]) {
-        idToken = user.idToken.tokenString;
-    }
-#endif
+    SEL idTokenSelector = NSSelectorFromString(@"idToken");
+    if ([user respondsToSelector:idTokenSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        id tokenObject = [user performSelector:idTokenSelector];
+#pragma clang diagnostic pop
 
-    if (idToken == nil && [user respondsToSelector:@selector(authentication)]) {
-        idToken = user.authentication.idToken;
+        SEL tokenStringSelector = NSSelectorFromString(@"tokenString");
+        if ([tokenObject respondsToSelector:tokenStringSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            id tokenString = [tokenObject performSelector:tokenStringSelector];
+#pragma clang diagnostic pop
+            if ([tokenString isKindOfClass:[NSString class]]) {
+                idToken = (NSString *)tokenString;
+            }
+        } else if ([tokenObject isKindOfClass:[NSString class]]) {
+            idToken = (NSString *)tokenObject;
+        }
+    }
+
+    if (idToken == nil) {
+        SEL authenticationSelector = NSSelectorFromString(@"authentication");
+        if ([user respondsToSelector:authenticationSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+            id authentication = [user performSelector:authenticationSelector];
+#pragma clang diagnostic pop
+
+            SEL legacyTokenSelector = NSSelectorFromString(@"idToken");
+            if ([authentication respondsToSelector:legacyTokenSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                id legacyToken = [authentication performSelector:legacyTokenSelector];
+#pragma clang diagnostic pop
+                if ([legacyToken isKindOfClass:[NSString class]]) {
+                    idToken = (NSString *)legacyToken;
+                }
+            }
+        }
     }
 
     NSDictionary *result = [self dictionaryForUser:user idToken:idToken];
@@ -111,15 +139,33 @@
 
     GIDSignIn *signIn = GIDSignIn.sharedInstance;
 
-#if __has_include(<GoogleSignIn/GIDSignInResult.h>)
-    [signIn signInWithConfiguration:config presentingViewController:self.viewController completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
-        [self sendPluginResultWithUser:signInResult.user error:error];
-    }];
-#else
-    [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-        [self sendPluginResultWithUser:user error:error];
-    }];
-#endif
+    SEL modernSignInSelector = NSSelectorFromString(@"signInWithConfiguration:presentingViewController:completion:");
+    if ([signIn respondsToSelector:modernSignInSelector]) {
+        void (^completion)(id _Nullable, NSError * _Nullable) = ^(id _Nullable signInResult, NSError * _Nullable error) {
+            GIDGoogleUser *user = nil;
+            if ([signInResult respondsToSelector:@selector(user)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+                id possibleUser = [signInResult performSelector:@selector(user)];
+#pragma clang diagnostic pop
+                if ([possibleUser isKindOfClass:[GIDGoogleUser class]]) {
+                    user = (GIDGoogleUser *)possibleUser;
+                }
+            } else if ([signInResult isKindOfClass:[GIDGoogleUser class]]) {
+                user = (GIDGoogleUser *)signInResult;
+            }
+
+            [self sendPluginResultWithUser:user error:error];
+        };
+
+        typedef void (*SignInWithCompletionType)(id, SEL, GIDConfiguration *, UIViewController *, void (^)(id _Nullable, NSError * _Nullable));
+        SignInWithCompletionType implementation = (SignInWithCompletionType)[signIn methodForSelector:modernSignInSelector];
+        implementation(signIn, modernSignInSelector, config, self.viewController, completion);
+    } else {
+        [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+            [self sendPluginResultWithUser:user error:error];
+        }];
+    }
 }
 
 
@@ -154,15 +200,30 @@
 }
 
 - (void) disconnect:(CDVInvokedUrlCommand*)command {
-    [GIDSignIn.sharedInstance disconnectWithCallback:^(NSError * _Nullable error) {
-        if(error == nil) {
+    GIDSignIn *signIn = GIDSignIn.sharedInstance;
+
+    void (^handleResult)(NSError * _Nullable) = ^(NSError * _Nullable error) {
+        if (error == nil) {
             CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"disconnected"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         } else {
             CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }
-    }];
+    };
+
+    SEL modernDisconnectSelector = NSSelectorFromString(@"disconnectWithCompletion:");
+    if ([signIn respondsToSelector:modernDisconnectSelector]) {
+        typedef void (*DisconnectWithCompletionType)(id, SEL, void (^ _Nullable)(NSError * _Nullable));
+        DisconnectWithCompletionType implementation = (DisconnectWithCompletionType)[signIn methodForSelector:modernDisconnectSelector];
+        implementation(signIn, modernDisconnectSelector, ^(NSError * _Nullable error) {
+            handleResult(error);
+        });
+    } else {
+        [signIn disconnectWithCallback:^(NSError * _Nullable error) {
+            handleResult(error);
+        }];
+    }
 }
 
 - (void) isSignedIn:(CDVInvokedUrlCommand*)command {

--- a/src/ios/GooglePlus.m
+++ b/src/ios/GooglePlus.m
@@ -2,6 +2,10 @@
 #import "objc/runtime.h"
 #import "GooglePlus.h"
 
+#if __has_include(<GoogleSignIn/GIDSignInResult.h>)
+#import <GoogleSignIn/GIDSignInResult.h>
+#endif
+
 @implementation GooglePlus
 
 - (void)pluginInitialize
@@ -31,6 +35,56 @@
 }
 
 
+- (NSDictionary *)dictionaryForUser:(GIDGoogleUser *)user idToken:(NSString *)idToken
+{
+    NSString *email = user.profile.email;
+    NSString *userId = user.userID;
+    NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
+
+    return @{
+        @"email"      : email ?: [NSNull null],
+        @"userId"     : userId ?: [NSNull null],
+        @"idToken"    : idToken ?: [NSNull null],
+        @"displayName": user.profile.name       ? : [NSNull null],
+        @"givenName"  : user.profile.givenName  ? : [NSNull null],
+        @"familyName" : user.profile.familyName ? : [NSNull null],
+        @"imageUrl"   : imageUrl ? imageUrl.absoluteString : [NSNull null],
+    };
+}
+
+- (void)sendPluginResultWithUser:(GIDGoogleUser *)user
+                           error:(NSError *)error
+{
+    if (error) {
+        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
+        return;
+    }
+
+    if (!user) {
+        CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"User information not available."];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
+        return;
+    }
+
+    NSString *idToken = nil;
+
+#if __has_include(<GoogleSignIn/GIDSignInResult.h>)
+    if ([user respondsToSelector:@selector(idToken)]) {
+        idToken = user.idToken.tokenString;
+    }
+#endif
+
+    if (idToken == nil && [user respondsToSelector:@selector(authentication)]) {
+        idToken = user.authentication.idToken;
+    }
+
+    NSDictionary *result = [self dictionaryForUser:user idToken:idToken];
+
+    CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
+}
+
 - (void) login:(CDVInvokedUrlCommand*)command {
     _callbackId = command.callbackId;
     NSDictionary* options = command.arguments[0];
@@ -57,28 +111,15 @@
 
     GIDSignIn *signIn = GIDSignIn.sharedInstance;
 
-    [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
-        if (error) {
-            CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
-        } else {
-            NSString *email = user.profile.email;
-            NSString *userId = user.userID;
-            NSURL *imageUrl = [user.profile imageURLWithDimension:120]; // TODO pass in img size as param, and try to sync with Android
-            NSDictionary *result = @{
-                           @"email"           : email,
-                           @"userId"          : userId,
-                           @"idToken"         : user.authentication.idToken,
-                           @"displayName"     : user.profile.name       ? : [NSNull null],
-                           @"givenName"       : user.profile.givenName  ? : [NSNull null],
-                           @"familyName"      : user.profile.familyName ? : [NSNull null],
-                           @"imageUrl"        : imageUrl ? imageUrl.absoluteString : [NSNull null],
-                           };
-
-            CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
-            [self.commandDelegate sendPluginResult:pluginResult callbackId:self->_callbackId];
-        }
+#if __has_include(<GoogleSignIn/GIDSignInResult.h>)
+    [signIn signInWithConfiguration:config presentingViewController:self.viewController completion:^(GIDSignInResult * _Nullable signInResult, NSError * _Nullable error) {
+        [self sendPluginResultWithUser:signInResult.user error:error];
     }];
+#else
+    [signIn signInWithConfiguration:config presentingViewController:self.viewController callback:^(GIDGoogleUser * _Nullable user, NSError * _Nullable error) {
+        [self sendPluginResultWithUser:user error:error];
+    }];
+#endif
 }
 
 


### PR DESCRIPTION
## Summary
- add helpers to centralize creating the plugin response from a signed-in user
- call the newer completion-based `signInWithConfiguration` API when `GIDSignInResult` is available while keeping the legacy callback path
- resolve ID token extraction for both new and legacy GoogleSignIn SDKs

## Testing
- not run (iOS build environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0eed805ec832d8bbdc1a3d4cc326a